### PR TITLE
add ps -w option to support systems where default width is limited

### DIFF
--- a/linuxprivchecker.py
+++ b/linuxprivchecker.py
@@ -297,7 +297,7 @@ def enum_procs_pkgs():
         getpkgs = "rpm -qa | sort -u"  # RH/other
 
     pkgsandprocs = {
-        "PROCS": {"cmd": "ps aux | awk '{print $1,$2,$9,$10,$11}'", "msg": "Current processes", "results": []},
+        "PROCS": {"cmd": "ps waux | awk '{print $1,$2,$9,$10,$11}'", "msg": "Current processes", "results": []},
         "PKGS": {"cmd": getpkgs, "msg": "Installed Packages", "results": []}
     }
 


### PR DESCRIPTION
On some systems, the default output from ps has a limited width, which can break running service detection.

This PR adds the 'w' option to resolve this issue.